### PR TITLE
Change 'multiple rows' to 'multiple columns

### DIFF
--- a/sections/05-side-note-on-data-structures-tidy-data.md
+++ b/sections/05-side-note-on-data-structures-tidy-data.md
@@ -57,7 +57,7 @@ Do you think you can explain the rules of tidy data structuring?
 
 ## Solution
 1. `Artist Role`, `Artist Display Name`, `Artist Display Bio`, `Artist Alpha Sort`, `Artist Nationality`, `Artist Begin Date`, `Artist End Date`, or `Classification`.
-2. I will choose to convert to the tidy data format if I was interested in any of the variables listed above, so that it will be easier to analyse the entries. I will have to unnest the entries by separating the data into different rows. For example, if I am interested in understanding the type of roles that are predominantly held by non-cisgender men, I will unnest the column `Artist Role`. An entry like `Architect|Artist` will be separated into two rows as illustrated in this example:
+2. I will choose to convert to the tidy data format if I was interested in any of the variables listed above, so that it will be easier to analyse the entries. I will have to unnest the entries by separating the data into different columns. For example, if I am interested in understanding the type of roles that are predominantly held by non-cisgender men, I will unnest the column `Artist Role`. An entry like `Architect|Artist` will be separated into two columns as illustrated in this example:
 
 ![Comparison of moSmall after tidy format](../images/moSmallComp.png)
 


### PR DESCRIPTION
I think in this dataset each row is a work, an item. So, adding a row is referring to the same item twice. Instead I would divide 'architect' and 'artist' into new columns, say 'artist role 1' and 'artist role 2'. This would also require updating the corresponding image. 
I could be mistaken!